### PR TITLE
Enabling CRON schedules for MEDIS ETL

### DIFF
--- a/dags/MEDIS-ETL.py
+++ b/dags/MEDIS-ETL.py
@@ -42,7 +42,7 @@ from airflow.models import Variable
 
 with DAG(
     dag_id="medis-etl",
-    #schedule="0 0 * * *",
+    schedule="0 13 * * 1-5",
     schedule=None,
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     catchup=False,

--- a/dags/MEDIS-ETL.py
+++ b/dags/MEDIS-ETL.py
@@ -42,7 +42,7 @@ from airflow.models import Variable
 
 with DAG(
     dag_id="medis-etl",
-    schedule="0 13 * * 1-5",
+    schedule="0 11 * * 1-5",
     schedule=None,
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     catchup=False,

--- a/dags/MEDIS-ODS-ETL.py
+++ b/dags/MEDIS-ODS-ETL.py
@@ -42,7 +42,7 @@ from airflow.models import Variable
 
 with DAG(
     dag_id="medis-ods-etl",
-    schedule="0 10 * * 1-5",
+    # schedule="0 10 * * 1-5",
     schedule=None,
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     catchup=False,

--- a/dags/MEDIS-ODS-ETL.py
+++ b/dags/MEDIS-ODS-ETL.py
@@ -42,7 +42,7 @@ from airflow.models import Variable
 
 with DAG(
     dag_id="medis-ods-etl",
-    #schedule="0 0 * * *",
+    schedule="0 10 * * 1-5",
     schedule=None,
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     catchup=False,


### PR DESCRIPTION
- According to Carlos, we should schedule the loads to be before or at 6AM on Mon-Fri for now.