### PR TITLE
add polling wrapper for SFTP empty-folder check

### DIFF
--- a/dags/airflow.app.job.emptysftp.yaml
+++ b/dags/airflow.app.job.emptysftp.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5400
   backoffLimit: 1
   selector:
     name: medis-emptysftp-job
@@ -36,7 +36,7 @@ spec:
         command:
         - "sh"
         - "-c"
-        - "/app/bin/emptysftp.sh"
+        - "/app/bin/emptysftp-polling.sh"
         envFrom:
           - configMapRef:
               name: medis-sftp-config-env

--- a/dags/emptysftp-polling.sh
+++ b/dags/emptysftp-polling.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Waits up to 90 minutes for the SFTP folder to become empty,
+# polling every 5 minutes instead of failing immediately.
+#
+MAX_WAIT_MINUTES=90
+POLL_INTERVAL_SECONDS=300  # 5 minutes
+MAX_ATTEMPTS=$((MAX_WAIT_MINUTES * 60 / POLL_INTERVAL_SECONDS))
+
+ATTEMPT=1
+while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+    echo "[Attempt $ATTEMPT/$MAX_ATTEMPTS] Checking if SFTP folder is empty..."
+    
+    /app/bin/emptysftp.sh
+    EXIT_CODE=$?
+    
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "SUCCESS: SFTP folder is empty. Proceeding with ETL."
+        exit 0
+    fi
+    
+    if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+        echo "SFTP folder not empty. Waiting $((POLL_INTERVAL_SECONDS / 60)) minutes before retry..."
+        sleep $POLL_INTERVAL_SECONDS
+    else
+        echo "TIMEOUT: SFTP folder still not empty after $MAX_WAIT_MINUTES minutes. Failing task."
+        exit 1
+    fi
+    
+    ATTEMPT=$((ATTEMPT + 1))
+done
+
+exit 1


### PR DESCRIPTION
add polling wrapper for SFTP empty-folder check (5 min interval, 90 min max wait) so that it won't fail immediately if the SFTP folder isn't empty.