### PR TITLE
increase timeout and include a buffer for the emptysftp.sh runtime

### DIFF
--- a/dags/airflow.app.job.emptydir.yaml
+++ b/dags/airflow.app.job.emptydir.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: medis-empty-job

--- a/dags/airflow.app.job.yaml
+++ b/dags/airflow.app.job.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: medis-sftp-job

--- a/dags/airflow.pg.backup.job.yaml
+++ b/dags/airflow.pg.backup.job.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   template:
     metadata:

--- a/dags/empty.sh
+++ b/dags/empty.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+echo "Check upload directory is empty"
+
+if timeout 30 ls -1 "${DATA_DIR}" >/tmp/ls_output 2>/dev/null; then
+    if [ ! -s /tmp/ls_output ]; then
+        echo "Empty"
+        exit 0
+    else
+        echo "Not Empty"
+        cat /tmp/ls_output
+        exit 1
+    fi
+else
+    echo "ERROR: Unable to access ${DATA_DIR} (timeout)"
+    exit 2
+fi

--- a/dags/ods.airflow.app.job.emptydir.yaml
+++ b/dags/ods.airflow.app.job.emptydir.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: medis-ods-empty-job

--- a/dags/ods.airflow.app.job.emptysftp.yaml
+++ b/dags/ods.airflow.app.job.emptysftp.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: medis-ods-emptysftp-job
@@ -35,7 +35,7 @@ spec:
           command:
             - 'sh'
             - '-c'
-            - '/app/bin/emptysftp.sh'
+            - '/app/bin/emptysftp-polling.sh'
           envFrom:
             - configMapRef:
                 name: medis-ods-sftp-config-env

--- a/dags/ods.airflow.app.job.yaml
+++ b/dags/ods.airflow.app.job.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: medis-ods-sftp-job

--- a/dags/pcd.airflow.app.job.emptydir.yaml
+++ b/dags/pcd.airflow.app.job.emptydir.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: pcd-empty-job

--- a/dags/pcd.airflow.app.job.emptysftp.yaml
+++ b/dags/pcd.airflow.app.job.emptysftp.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: pcd-emptysftp-job
@@ -36,7 +36,7 @@ spec:
         command:
         - "sh"
         - "-c"
-        - "/app/bin/emptysftp.sh"
+        - "/app/bin/emptysftp-polling.sh"
         envFrom:
           - configMapRef:
               name: pcd-sftp-config-env

--- a/dags/pcd.airflow.app.job.yaml
+++ b/dags/pcd.airflow.app.job.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: pcd-sftp-job

--- a/dags/poly.airflow.app.job.emptydir.yaml
+++ b/dags/poly.airflow.app.job.emptydir.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: poly-empty-job

--- a/dags/poly.airflow.app.job.emptysftp.yaml
+++ b/dags/poly.airflow.app.job.emptysftp.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: poly-emptysftp-job
@@ -36,7 +36,7 @@ spec:
         command:
         - "sh"
         - "-c"
-        - "/app/bin/emptysftp.sh"
+        - "/app/bin/emptysftp-polling.sh"
         envFrom:
           - configMapRef:
               name: poly-sftp-config-env

--- a/dags/poly.airflow.app.job.yaml
+++ b/dags/poly.airflow.app.job.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   selector:
     name: poly-sftp-job

--- a/dags/rls.pg.backup.job.yaml
+++ b/dags/rls.pg.backup.job.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 5700
   backoffLimit: 1
   template:
     metadata:


### PR DESCRIPTION
- increased the timeout on all the "Check_LTC_SFTP_Folder" and "Check_LTC_Shared_Folder" steps in the Airflow DAGs
- added the retry mechanism for all other SFTP checks (medis-ods-etl, pcd-etl, poly-etl), polling every 5 minutes for up to 90 minutes
- Updated empty.sh to wrap the ls command with a timeout of 30s, ensuring it fails fast instead of hanging