### PR TITLE
upgrade airflow from v2.9.0 to v3.2.2

### DIFF
--- a/dags/MEDIS-ETL.py
+++ b/dags/MEDIS-ETL.py
@@ -27,14 +27,14 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/MEDIS-ETL.py
+++ b/dags/MEDIS-ETL.py
@@ -34,7 +34,7 @@ from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperato
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/MEDIS-ODS-ETL.py
+++ b/dags/MEDIS-ODS-ETL.py
@@ -27,14 +27,14 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/MEDIS-ODS-ETL.py
+++ b/dags/MEDIS-ODS-ETL.py
@@ -34,7 +34,7 @@ from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperato
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/PCD-ETL.py
+++ b/dags/PCD-ETL.py
@@ -32,7 +32,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/PCD-ETL.py
+++ b/dags/PCD-ETL.py
@@ -26,13 +26,13 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/POLY-ETL.py
+++ b/dags/POLY-ETL.py
@@ -26,7 +26,7 @@ from airflow.models.dag import DAG
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.models import Variable
 

--- a/dags/POLY-ETL.py
+++ b/dags/POLY-ETL.py
@@ -23,10 +23,10 @@ import datetime
 import pendulum
 
 from airflow.models.dag import DAG
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.models import Variable
 

--- a/dags/YTD-ETL-test.py
+++ b/dags/YTD-ETL-test.py
@@ -32,7 +32,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.email_operator import EmailOperator
+from airflow.operators.email import EmailOperator
 
 
 with DAG(

--- a/dags/YTD-ETL-test.py
+++ b/dags/YTD-ETL-test.py
@@ -26,13 +26,13 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.email import EmailOperator
+from airflow.providers.smtp.operators.smtp import EmailOperator
 
 
 with DAG(

--- a/dags/airflow-backup.py
+++ b/dags/airflow-backup.py
@@ -32,7 +32,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/airflow-backup.py
+++ b/dags/airflow-backup.py
@@ -26,13 +26,13 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/example_bash_operator_test.py
+++ b/dags/example_bash_operator_test.py
@@ -23,8 +23,8 @@ import datetime
 import pendulum
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 
 with DAG(
     dag_id="example_bash_operator_test",

--- a/dags/get_failed_ids_http_example.py
+++ b/dags/get_failed_ids_http_example.py
@@ -24,8 +24,8 @@ import pendulum
 
 from airflow.models.dag import DAG
 from airflow.providers.http.operators.http import HttpOperator
-from airflow.operators.python import PythonOperator
-from airflow.operators.email import EmailOperator
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.providers.smtp.operators.smtp import EmailOperator
 from airflow.exceptions import AirflowSkipException
 
 with DAG(

--- a/dags/get_failed_ids_http_example.py
+++ b/dags/get_failed_ids_http_example.py
@@ -24,8 +24,8 @@ import pendulum
 
 from airflow.models.dag import DAG
 from airflow.providers.http.operators.http import HttpOperator
-from airflow.operators.python_operator import PythonOperator
-from airflow.operators.email_operator import EmailOperator
+from airflow.operators.python import PythonOperator
+from airflow.operators.email import EmailOperator
 from airflow.exceptions import AirflowSkipException
 
 with DAG(

--- a/dags/get_failed_ids_send_email.py
+++ b/dags/get_failed_ids_send_email.py
@@ -23,8 +23,8 @@ import datetime
 import pendulum
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.exceptions import AirflowSkipException
 from airflow.models import Variable

--- a/dags/get_failed_ids_send_email.py
+++ b/dags/get_failed_ids_send_email.py
@@ -24,7 +24,7 @@ import pendulum
 
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.exceptions import AirflowSkipException
 from airflow.models import Variable

--- a/dags/rls-backup.py
+++ b/dags/rls-backup.py
@@ -32,7 +32,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/rls-backup.py
+++ b/dags/rls-backup.py
@@ -26,13 +26,13 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/test-email.py
+++ b/dags/test-email.py
@@ -5,7 +5,7 @@ import datetime
 import pendulum
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.operators.empty import EmptyOperator
 

--- a/dags/test-email.py
+++ b/dags/test-email.py
@@ -4,10 +4,10 @@ import datetime
 
 import pendulum
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.email import send_email
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 
 def send_success_status_email(context):
     task_instance = context['task_instance']

--- a/dags/test_DAG.py
+++ b/dags/test_DAG.py
@@ -32,7 +32,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/test_DAG.py
+++ b/dags/test_DAG.py
@@ -26,13 +26,13 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@
 # The following variables are supported:
 #
 # AIRFLOW_IMAGE_NAME           - Docker image name used to run Airflow.
-#                                Default: apache/airflow:2.9.0
+#                                Default: apache/airflow:3.2.2
 # AIRFLOW_UID                  - User ID in Airflow containers
 #                                Default: 50000
 # AIRFLOW_PROJ_DIR             - Base path to which all the files will be volumed.
@@ -49,7 +49,7 @@ x-airflow-common:
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
-  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.9.0}
+  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:3.2.2}
   # build: .
   environment:
     &airflow-common-env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -117,11 +117,11 @@ services:
 
   airflow-webserver:
     <<: *airflow-common
-    command: webserver
+    command: api-server
     ports:
       - "8080:8080"
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/monitor/health"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
this PR upgrades local Airflow runtime compatibility to Airflow 3.2.2 and updates DAG operator imports to Airflow 3 provider-specific paths.

- Updated Airflow image in docker-compose.yaml to 3.2.2.
- Updated local web component command in docker-compose.yaml:
    - webserver -> api-server
- Updated local web healthcheck in docker-compose.yaml:
    - /health -> /api/v2/monitor/health
- Replaced deprecated imports in DAGs:
    - airflow.operators.bash -> airflow.providers.standard.operators.bash
    - airflow.operators.empty -> airflow.providers.standard.operators.empty
    - airflow.operators.python -> airflow.providers.standard.operators.python
    - airflow.operators.email -> airflow.providers.smtp.operators.smtp
