### PR TITLE
Upload helm override yaml file and fix DAG email notification logic after airflow upgrade

### DIFF
--- a/airflow/override-values-c2da03-prod.yaml
+++ b/airflow/override-values-c2da03-prod.yaml
@@ -1,17 +1,57 @@
-uid: 1014610001
-gid: 1014610001
+# MEDIS Airflow values for OpenShift PROD after the Airflow 3 upgrade.
+# This file is intended to be the single environment override file used with chart airflow-1.22.0.
 
+# Keep the existing Airflow resource names/PVC names rather than switching to standard naming.
+useStandardNaming: false
+
+# Airflow 3 target version.
+airflowVersion: 3.2.2
+images:
+  airflow:
+    tag: 3.2.2
+  # Give app pods more time while the migration job updates the existing metadata DB.
+  migrationsWaitTimeout: 300
+
+# OpenShift assigned UID range and allowed filesystem group for c2da03-prod.
+# uid must be in 1014610000-1014619999; fsGroup/gid must be in the supplemental group range.
+uid: 1014610001
+gid: 1000660001
+
+# Preserve the OpenShift supplemental group that the previous Airflow 2.9 release used.
 securityContext:
   supplementalGroups: [1000660001]
 
+# Disable the legacy airflow_local_settings.py template. The old template imports airflow.www,
+# which is not available in Airflow 3.
+airflowLocalSettings: null
+
+# Use stable, named Secrets so Helm does not generate new runtime secrets on every upgrade.
+fernetKeySecretName: airflow-fernet-key
+apiSecretKeySecretName: airflow-api-secret-key
+jwtSecretName: airflow-jwt-secret
+webserverSecretKeySecretName: airflow-webserver-secret-key
+
+# With helm --wait, run these as normal Kubernetes Jobs instead of post-upgrade hooks.
+# Otherwise the Airflow pods wait for migrations before the post-upgrade hook job is created.
+createUserJob:
+  useHelmHooks: false
+  applyCustomEnv: false
+
+migrateDatabaseJob:
+  enabled: true
+  useHelmHooks: false
+  applyCustomEnv: false
+
 workers:
   persistence:
+    enabled: true
     size: 5Gi
   resources:
     limits:
-      memory: 4Gi  
+      memory: 4Gi
 
-webserver:
+# Airflow 3 uses apiServer instead of the Airflow 2 webserver component.
+apiServer:
   resources:
     limits:
       cpu: 300m
@@ -47,9 +87,9 @@ scheduler:
       cpu: 150m
       memory: 256Mi
 
-
 triggerer:
   persistence:
+    enabled: true
     size: 5Gi
 
 statsd:
@@ -74,24 +114,66 @@ dags:
     subPath: "dags"
 
 postgresql:
+  enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 16.1.0-debian-11-r15
+
+  # Bitnami PostgreSQL chart 13.x defaults to UID/GID 1001 and fsGroup 1001.
+  # Those are rejected by OpenShift restricted-v2 in this namespace, so keep
+  # the old OpenShift-compatible postgres UID and avoid the fsGroup/explicit seccomp defaults.
   primary:
+    podSecurityContext:
+      enabled: false
     containerSecurityContext:
+      enabled: true
       runAsUser: 1014610003
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
   readReplicas:
+    podSecurityContext:
+      enabled: false
     containerSecurityContext:
+      enabled: true
       runAsUser: 1014610003
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
   backup:
     cronjob:
+      podSecurityContext:
+        enabled: false
       containerSecurityContext:
+        enabled: true
         runAsUser: 1014610003
+        runAsNonRoot: true
+        privileged: false
+        readOnlyRootFilesystem: false
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+
+  volumePermissions:
+    enabled: false
+  shmVolume:
+    enabled: false
 
 config:
-  webserver:
-    expose_config: 'True'  # by default this is 'False'
+  api:
+    expose_config: "True"
 
   smtp:
-    smtp_host: apps.smtp.gov.bc.ca  # befoult 'localhost'
-    smtp_mail_from: airflow@gov.bc.ca # default 'airflow@example.com'
-
-
-  
+    smtp_host: apps.smtp.gov.bc.ca
+    smtp_mail_from: airflow@gov.bc.ca

--- a/airflow/override-values-c2da03-test.yaml
+++ b/airflow/override-values-c2da03-test.yaml
@@ -1,17 +1,57 @@
-uid: 1014620001
-gid: 1014620001
+# MEDIS Airflow values for OpenShift TEST after the Airflow 3 upgrade.
+# This file is intended to be the single environment override file used with chart airflow-1.22.0.
 
+# Keep the existing Airflow resource names/PVC names rather than switching to standard naming.
+useStandardNaming: false
+
+# Airflow 3 target version.
+airflowVersion: 3.2.2
+images:
+  airflow:
+    tag: 3.2.2
+  # Give app pods more time while the migration job updates the existing metadata DB.
+  migrationsWaitTimeout: 300
+
+# OpenShift assigned UID range and allowed filesystem group for c2da03-test.
+# uid must be in 1014620000-1014629999; fsGroup/gid must be in the supplemental group range.
+uid: 1014620001
+gid: 1000660001
+
+# Preserve the OpenShift supplemental group that the previous Airflow 2.9 release used.
 securityContext:
   supplementalGroups: [1000660001]
 
+# Disable the legacy airflow_local_settings.py template. The old template imports airflow.www,
+# which is not available in Airflow 3.
+airflowLocalSettings: null
+
+# Use stable, named Secrets so Helm does not generate new runtime secrets on every upgrade.
+fernetKeySecretName: airflow-fernet-key
+apiSecretKeySecretName: airflow-api-secret-key
+jwtSecretName: airflow-jwt-secret
+webserverSecretKeySecretName: airflow-webserver-secret-key
+
+# With helm --wait, run these as normal Kubernetes Jobs instead of post-upgrade hooks.
+# Otherwise the Airflow pods wait for migrations before the post-upgrade hook job is created.
+createUserJob:
+  useHelmHooks: false
+  applyCustomEnv: false
+
+migrateDatabaseJob:
+  enabled: true
+  useHelmHooks: false
+  applyCustomEnv: false
+
 workers:
   persistence:
+    enabled: true
     size: 5Gi
   resources:
     limits:
-      memory: 4Gi  
+      memory: 4Gi
 
-webserver:
+# Airflow 3 uses apiServer instead of the Airflow 2 webserver component.
+apiServer:
   resources:
     limits:
       cpu: 300m
@@ -47,9 +87,9 @@ scheduler:
       cpu: 150m
       memory: 256Mi
 
-
 triggerer:
   persistence:
+    enabled: true
     size: 5Gi
 
 statsd:
@@ -74,25 +114,66 @@ dags:
     subPath: "dags"
 
 postgresql:
+  enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 16.1.0-debian-11-r15
+
+  # Bitnami PostgreSQL chart 13.x defaults to UID/GID 1001 and fsGroup 1001.
+  # Those are rejected by OpenShift restricted-v2 in this namespace, so keep
+  # the old OpenShift-compatible postgres UID and avoid the fsGroup/explicit seccomp defaults.
   primary:
+    podSecurityContext:
+      enabled: false
     containerSecurityContext:
+      enabled: true
       runAsUser: 1014620003
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
   readReplicas:
+    podSecurityContext:
+      enabled: false
     containerSecurityContext:
+      enabled: true
       runAsUser: 1014620003
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
   backup:
     cronjob:
+      podSecurityContext:
+        enabled: false
       containerSecurityContext:
+        enabled: true
         runAsUser: 1014620003
-     
+        runAsNonRoot: true
+        privileged: false
+        readOnlyRootFilesystem: false
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+
+  volumePermissions:
+    enabled: false
+  shmVolume:
+    enabled: false
 
 config:
-  webserver:
-    expose_config: 'True'  # by default this is 'False'
+  api:
+    expose_config: "True"
 
   smtp:
-    smtp_host: apps.smtp.gov.bc.ca  # befoult 'localhost'
-    smtp_mail_from: airflow@gov.bc.ca # default 'airflow@example.com'
-
-
-  
+    smtp_host: apps.smtp.gov.bc.ca
+    smtp_mail_from: airflow@gov.bc.ca

--- a/dags/MEDIS-ETL.py
+++ b/dags/MEDIS-ETL.py
@@ -38,6 +38,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 medis_schedule = Variable.get("medis_schedule")
 medis_last_load_date = Variable.get("medis_last_load_date")
@@ -78,11 +79,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/MEDIS-ODS-ETL.py
+++ b/dags/MEDIS-ODS-ETL.py
@@ -38,6 +38,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 medis_ods_etl_schedule = Variable.get("medis_ods_etl_schedule")
 
@@ -77,11 +78,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/PCD-ETL.py
+++ b/dags/PCD-ETL.py
@@ -36,6 +36,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 pcd_etl_schedule = Variable.get("pcd_etl_schedule")
 
@@ -75,11 +76,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/POLY-ETL.py
+++ b/dags/POLY-ETL.py
@@ -29,6 +29,7 @@ from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperato
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 poly_etl_schedule = Variable.get("poly_etl_schedule")
 
@@ -68,11 +69,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/airflow-backup.py
+++ b/dags/airflow-backup.py
@@ -36,6 +36,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 
 with DAG(
@@ -75,11 +76,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/get_failed_ids_http_example.py
+++ b/dags/get_failed_ids_http_example.py
@@ -27,6 +27,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.smtp.operators.smtp import EmailOperator
 from airflow.exceptions import AirflowSkipException
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 with DAG(
     dag_id="test_ETL_notification",
@@ -41,12 +42,20 @@ with DAG(
     def get_failed_ids(ds=None, **kwargs):
         ti = kwargs['ti']
         dag_run = kwargs['dag_run']
+        dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection([task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, skip this task
         if len(failed_upstream_task_ids) == 0:

--- a/dags/get_failed_ids_send_email.py
+++ b/dags/get_failed_ids_send_email.py
@@ -28,6 +28,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.exceptions import AirflowSkipException
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 with DAG(
     dag_id="test_fail_success_send_email",
@@ -64,11 +65,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/rls-backup.py
+++ b/dags/rls-backup.py
@@ -36,6 +36,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 
 with DAG(
@@ -75,11 +76,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/test_DAG.py
+++ b/dags/test_DAG.py
@@ -36,6 +36,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 
 with DAG(
@@ -75,11 +76,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:


### PR DESCRIPTION
## Summary

This PR prepares MEDIS Scheduler for the Airflow 3.2.2 upgrade on OpenShift and fixes DAG email notification logic that failed after the upgrade.

The Helm override files are updated to use the Airflow 3 chart structure and OpenShift-compatible security settings. DAG notification tasks are also patched to avoid the Airflow 2.x `dag_run.get_task_instances()` call, which is no longer available in the Airflow 3 task runtime context.

## Changes

### Airflow / Helm override updates

- Pin Airflow to `3.2.2`.
- Update Helm values for the Airflow 3 chart.
- Replace the Airflow 2 `webserver` component settings with Airflow 3 `apiServer` settings.
- Move `config.webserver.expose_config` to `config.api.expose_config`.
- Disable legacy `airflowLocalSettings` injection.
- Configure migration and create-user jobs as normal Kubernetes jobs instead of Helm hooks.
- Increase migration wait timeout for existing metadata DB upgrades.
- Pin PostgreSQL to the working legacy Bitnami image:
  - `bitnamilegacy/postgresql:16.1.0-debian-11-r15`
- Preserve OpenShift-specific UID/GID/security context values.
- Keep PROD-specific values such as:
  - PROD UID range
  - PROD PostgreSQL runAsUser
  - PROD Redis/statsd/pgbouncer UIDs
  - PROD DAG git-sync branch: `main`

### DAG notification compatibility

- Fix notification tasks that were using the Airflow 2.x pattern:
  - `dag_run.get_task_instances(state='failed')`
- Replace that with Airflow 3-compatible task state lookup logic.
- Keep the notification behavior unchanged:
  - send success email when no upstream task failed
  - send failure email with failed upstream task IDs when upstream failures exist
- Avoid unrelated cleanup/refactoring so the DAG changes stay minimal and easy to review.

## Why

After upgrading to Airflow 3.2.2, notification tasks failed with:

```text
AttributeError: 'DagRun' object has no attribute 'get_task_instances'