### PR TITLE
Apache Airflow upgrade from v2.9.0 to v3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,128 @@
 # medis-scheduler
+
 ## MoH MEDIS project ETL scheduler
 
+Apache Airflow is an open-source workflow management platform for data engineering pipelines. It was chosen as our ETL process scheduler.
 
-Apache Airflow is an open-source workflow management platform for data engineering pipelines. It was chosen as our ETL process scheduler. 
-Airflow was deployed to OpenShift using Helm Chart downloaded to the local directory (laptop with Windows). It also can be installed directly from helm-chart repository ([https://airflow.apache.org/docs/helm-chart/stable/index.html])
-### Airflow installation.
-(The installation requires OpenShift CLI (oc) and helm to be installed on your OS)
-1.	Connect to OpenShift platform.
-From [https://oauth-openshift.apps.silver.devops.gov.bc.ca/oauth/token/display] get the API token.
-Copy oc command with the token to login and run it from your laptop. (Laptop should have access to government’s OpenShift).
-The example of your command:
-oc login --token=sha256~yxiCAMwFD_XXX --server=https://api.silver.devops.gov.bc.ca:6443
-Logged into [https://api.silver.devops.gov.bc.ca:6443] as "username@github" using the token provided.
-2.	Choose the project you going to deploy or upgrade Airflow to.
-3.	Run the helm command to install/upgrade Airflow:
-helm.exe upgrade --install airflow C:\path-to-helm-chart\helm-v3.14.3-windows-amd64\windows-amd64\airflow-1.13.0\airflow-1.13.0\airflow --namespace c2da03-test -f C:\Users\tatiana.pluzhnikova\Downloads\helm-v3.14.3-windows-amd64\windows-amd64\airflow-1.13.0\airflow-1.13.0\airflow\override-values-c2da03-test.yaml
+Airflow is deployed to OpenShift using the Apache Airflow Helm chart. The current deployment is based on Airflow `3.2.2` and Helm chart `1.22.0`.
 
-This command uses the downloaded helm-chart for installation and the default settings will be overwritten with override-values-c2da03-test.yaml file which can be found in GitHub [https://github.com/bcgov/medis-scheduler/blob/6ef9eb0d6c5d61751b796123ae13484d29ca9de8/airflow/override-values-c2da03-test.yaml]
+## Airflow installation
 
+The installation requires the OpenShift CLI (`oc`) and Helm to be installed on your OS.
 
-### Airflow configuration
-1.	Airflow can be accessed at [https://airflow-webserver-c2da03-test.apps.silver.devops.gov.bc.ca/] and [https://airflow-webserver-c2da03-prod.apps.silver.devops.gov.bc.ca/]  
-2.	The DAGs are stored in GitHub  (medis-scheduler/dags at main · bcgov/medis-scheduler (github.com)) and being synced to Airflow every 10 seconds from test branch to test Airflow and from main branch to prod Airflow. 
-(We try to do changes it test branch first then do pull request to main branch)
-3.	We use Airflow Variables for more flexibility, so some parameters can be modified without touching the DAGs. The variables can be exported and imported to/from json format file and we keep them in GitHub [https://github.com/bcgov/medis-scheduler/tree/6ef9eb0d6c5d61751b796123ae13484d29ca9de8/airflow]
+1. Connect to the OpenShift platform. From <https://oauth-openshift.apps.silver.devops.gov.bc.ca/oauth/token/display>, get the API token. Copy the `oc login` command with the token and run it from your laptop. The laptop must have access to the government OpenShift cluster.
 
-### Airflow PCD-ETL and MEDIS-ETL DAGs description.
-Airflow scheduler perform the same ETL steps as described there: https://proactionca.ent.cgi.com/confluence/pages/viewpage.action?spaceKey=BCMOHAD&title=ETL+process+design and ([https://proactionca.ent.cgi.com/confluence/display/BCMOHAD/Manual+trigger+for+ETL+process] ) plus we added extra steps for error handling, email notifications…
-1.	The extract phase is done by calling ETL service endpoint in OpenShift with Airflow HttpOperator. The URLs for each form being extracted are defined as Airflow variables. The payload is hardcoded in DAG.
-2.	Files uploader is implemented as a job on OpenShift and triggered by Airflow KubernetesJobOperator (task PCD_file_upload or MEDIS_file_upload) 
-The job spins a pod that executes upload.sh file that creates combined medis_ltc.flag file, uploads all encrypted files, uploads newly created flag file, moves all files into archive directory and also deletes files from archive directory that are older than specified retention period. ([https://proactionca.ent.cgi.com/confluence/display/BCMOHAD/Manual+trigger+for+ETL+process])
+   Example:
 
+   ```cmd
+   oc login --token=sha256~xxxxxxxxxxxxx --server=https://api.silver.devops.gov.bc.ca:6443
+   ```
 
+2. Choose the OpenShift project where Airflow will be installed or upgraded.
 
+   ```cmd
+   oc project c2da03-test
+   ```
 
-## Running Locally
+   or:
 
-### Pre-requisite
+   ```cmd
+   oc project c2da03-prod
+   ```
 
-- Docker[https://docs.docker.com/engine/install/]
-- Docker Compose[https://docs.docker.com/compose/install/]
+3. Add/update the Apache Airflow Helm chart repository.
+
+   ```cmd
+   helm repo add apache-airflow https://airflow.apache.org
+   helm repo update
+   ```
+
+4. Run the Helm command to install/upgrade Airflow.
+
+   TEST:
+
+   ```cmd
+   helm.exe upgrade --install airflow apache-airflow/airflow --namespace c2da03-test --version 1.22.0 -f airflow\override-values-c2da03-test.yaml --reset-values --wait --wait-for-jobs --timeout 30m
+   ```
+
+   PROD:
+
+   ```cmd
+   helm.exe upgrade --install airflow apache-airflow/airflow --namespace c2da03-prod --version 1.22.0 -f airflow\override-values-c2da03-prod.yaml --reset-values --wait --wait-for-jobs --timeout 30m
+   ```
+
+   The override files contain the OpenShift-specific Airflow settings for each environment:
+
+   - `airflow/override-values-c2da03-test.yaml`
+   - `airflow/override-values-c2da03-prod.yaml`
+
+   For the Airflow 3 upgrade, use `--reset-values` so old Airflow 2 chart values are not reused.
+
+## Airflow configuration
+
+1. Airflow can be accessed at:
+
+   - <https://airflow-webserver-c2da03-test.apps.silver.devops.gov.bc.ca/>
+   - <https://airflow-webserver-c2da03-prod.apps.silver.devops.gov.bc.ca/>
+
+   In Airflow 3, the backend service is `airflow-api-server` instead of the old `airflow-webserver` service. The existing route URL can remain the same, but the OpenShift route should point to service `airflow-api-server` on port `8080`.
+
+2. DAGs are stored in GitHub under `medis-scheduler/dags` and are synced to Airflow from GitHub every 10 seconds:
+
+   - TEST Airflow syncs from the `test` branch.
+   - PROD Airflow syncs from the `main` branch.
+
+   Changes should be tested in the `test` branch first, then promoted to `main` through a pull request.
+
+3. Airflow Variables are used for flexibility, so some parameters can be modified without changing the DAG code. Variables can be exported/imported as JSON files and are stored in the `airflow` folder in this repository.
+
+## Airflow PCD-ETL, MEDIS-ETL, and related DAGs
+
+Airflow scheduler performs the same ETL steps as described in the project ETL design documentation:
+
+- <https://proactionca.ent.cgi.com/confluence/pages/viewpage.action?spaceKey=BCMOHAD&title=ETL+process+design>
+- <https://proactionca.ent.cgi.com/confluence/display/BCMOHAD/Manual+trigger+for+ETL+process>
+
+Additional steps are included for error handling and email notifications.
+
+1. The extract phase calls the ETL service endpoint in OpenShift using Airflow `HttpOperator`. The URLs for each form being extracted are defined as Airflow Variables.
+
+2. The payload is hardcoded in the DAG.
+
+3. File upload is implemented as a job on OpenShift and triggered by Airflow `KubernetesJobOperator`. The job runs a pod that executes `upload.sh`, creates the combined `medis_ltc.flag` file, uploads encrypted files, uploads the newly created flag file, moves files into the archive directory, and deletes archived files older than the configured retention period.
+
+4. DAG notification logic is compatible with Airflow 3.2.2.
+
+## Running locally
+
+### Prerequisites
+
+- Docker: <https://docs.docker.com/engine/install/>
+- Docker Compose: <https://docs.docker.com/compose/install/>
 
 ### Running locally
 
-- Create "config", "logs" and "plugins" directories on the same level as dags.
+The local Docker Compose setup uses Airflow `3.2.2`. The compose service name remains `airflow-webserver`, but it runs the Airflow 3 `api-server` command.
 
-- Run the following command to initialize the Docker Containers.
+1. Create `config`, `logs`, and `plugins` directories on the same level as `dags`.
 
-```bash
-docker-compose up airflow-init
-```
+2. Run the following command to initialize the Docker containers.
 
-- Run the following command to start the Airflow instance.
+   ```bash
+   docker-compose up airflow-init
+   ```
 
-```bash
-docker-compose up
-```
+3. Run the following command to start the Airflow instance.
 
-- You can access the Airflow instance at [http://localhost:8080/](http://localhost:8080/), and log in with username "airflow" and password "airflow".
+   ```bash
+   docker-compose up
+   ```
 
-- You can then start or stop the deployment when developing.
+4. Access Airflow locally at <http://localhost:8080/> and log in with username `airflow` and password `airflow`.
 
 ### Clean up
 
-- Run the following command to delete all containers and free up memory.
+Run the following command to delete all containers and free up memory.
 
 ```bash
 docker-compose down --volumes --remove-orphans

--- a/airflow/override-values-c2da03-prod.yaml
+++ b/airflow/override-values-c2da03-prod.yaml
@@ -1,17 +1,57 @@
-uid: 1014610001
-gid: 1014610001
+# MEDIS Airflow values for OpenShift PROD after the Airflow 3 upgrade.
+# This file is intended to be the single environment override file used with chart airflow-1.22.0.
 
+# Keep the existing Airflow resource names/PVC names rather than switching to standard naming.
+useStandardNaming: false
+
+# Airflow 3 target version.
+airflowVersion: 3.2.2
+images:
+  airflow:
+    tag: 3.2.2
+  # Give app pods more time while the migration job updates the existing metadata DB.
+  migrationsWaitTimeout: 300
+
+# OpenShift assigned UID range and allowed filesystem group for c2da03-prod.
+# uid must be in 1014610000-1014619999; fsGroup/gid must be in the supplemental group range.
+uid: 1014610001
+gid: 1000660001
+
+# Preserve the OpenShift supplemental group that the previous Airflow 2.9 release used.
 securityContext:
   supplementalGroups: [1000660001]
 
+# Disable the legacy airflow_local_settings.py template. The old template imports airflow.www,
+# which is not available in Airflow 3.
+airflowLocalSettings: null
+
+# Use stable, named Secrets so Helm does not generate new runtime secrets on every upgrade.
+fernetKeySecretName: airflow-fernet-key
+apiSecretKeySecretName: airflow-api-secret-key
+jwtSecretName: airflow-jwt-secret
+webserverSecretKeySecretName: airflow-webserver-secret-key
+
+# With helm --wait, run these as normal Kubernetes Jobs instead of post-upgrade hooks.
+# Otherwise the Airflow pods wait for migrations before the post-upgrade hook job is created.
+createUserJob:
+  useHelmHooks: false
+  applyCustomEnv: false
+
+migrateDatabaseJob:
+  enabled: true
+  useHelmHooks: false
+  applyCustomEnv: false
+
 workers:
   persistence:
+    enabled: true
     size: 5Gi
   resources:
     limits:
-      memory: 4Gi  
+      memory: 4Gi
 
-webserver:
+# Airflow 3 uses apiServer instead of the Airflow 2 webserver component.
+apiServer:
   resources:
     limits:
       cpu: 300m
@@ -47,9 +87,9 @@ scheduler:
       cpu: 150m
       memory: 256Mi
 
-
 triggerer:
   persistence:
+    enabled: true
     size: 5Gi
 
 statsd:
@@ -74,24 +114,66 @@ dags:
     subPath: "dags"
 
 postgresql:
+  enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 16.1.0-debian-11-r15
+
+  # Bitnami PostgreSQL chart 13.x defaults to UID/GID 1001 and fsGroup 1001.
+  # Those are rejected by OpenShift restricted-v2 in this namespace, so keep
+  # the old OpenShift-compatible postgres UID and avoid the fsGroup/explicit seccomp defaults.
   primary:
+    podSecurityContext:
+      enabled: false
     containerSecurityContext:
+      enabled: true
       runAsUser: 1014610003
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
   readReplicas:
+    podSecurityContext:
+      enabled: false
     containerSecurityContext:
+      enabled: true
       runAsUser: 1014610003
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
   backup:
     cronjob:
+      podSecurityContext:
+        enabled: false
       containerSecurityContext:
+        enabled: true
         runAsUser: 1014610003
+        runAsNonRoot: true
+        privileged: false
+        readOnlyRootFilesystem: false
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+
+  volumePermissions:
+    enabled: false
+  shmVolume:
+    enabled: false
 
 config:
-  webserver:
-    expose_config: 'True'  # by default this is 'False'
+  api:
+    expose_config: "True"
 
   smtp:
-    smtp_host: apps.smtp.gov.bc.ca  # befoult 'localhost'
-    smtp_mail_from: airflow@gov.bc.ca # default 'airflow@example.com'
-
-
-  
+    smtp_host: apps.smtp.gov.bc.ca
+    smtp_mail_from: airflow@gov.bc.ca

--- a/airflow/override-values-c2da03-test.yaml
+++ b/airflow/override-values-c2da03-test.yaml
@@ -1,17 +1,57 @@
-uid: 1014620001
-gid: 1014620001
+# MEDIS Airflow values for OpenShift TEST after the Airflow 3 upgrade.
+# This file is intended to be the single environment override file used with chart airflow-1.22.0.
 
+# Keep the existing Airflow resource names/PVC names rather than switching to standard naming.
+useStandardNaming: false
+
+# Airflow 3 target version.
+airflowVersion: 3.2.2
+images:
+  airflow:
+    tag: 3.2.2
+  # Give app pods more time while the migration job updates the existing metadata DB.
+  migrationsWaitTimeout: 300
+
+# OpenShift assigned UID range and allowed filesystem group for c2da03-test.
+# uid must be in 1014620000-1014629999; fsGroup/gid must be in the supplemental group range.
+uid: 1014620001
+gid: 1000660001
+
+# Preserve the OpenShift supplemental group that the previous Airflow 2.9 release used.
 securityContext:
   supplementalGroups: [1000660001]
 
+# Disable the legacy airflow_local_settings.py template. The old template imports airflow.www,
+# which is not available in Airflow 3.
+airflowLocalSettings: null
+
+# Use stable, named Secrets so Helm does not generate new runtime secrets on every upgrade.
+fernetKeySecretName: airflow-fernet-key
+apiSecretKeySecretName: airflow-api-secret-key
+jwtSecretName: airflow-jwt-secret
+webserverSecretKeySecretName: airflow-webserver-secret-key
+
+# With helm --wait, run these as normal Kubernetes Jobs instead of post-upgrade hooks.
+# Otherwise the Airflow pods wait for migrations before the post-upgrade hook job is created.
+createUserJob:
+  useHelmHooks: false
+  applyCustomEnv: false
+
+migrateDatabaseJob:
+  enabled: true
+  useHelmHooks: false
+  applyCustomEnv: false
+
 workers:
   persistence:
+    enabled: true
     size: 5Gi
   resources:
     limits:
-      memory: 4Gi  
+      memory: 4Gi
 
-webserver:
+# Airflow 3 uses apiServer instead of the Airflow 2 webserver component.
+apiServer:
   resources:
     limits:
       cpu: 300m
@@ -47,9 +87,9 @@ scheduler:
       cpu: 150m
       memory: 256Mi
 
-
 triggerer:
   persistence:
+    enabled: true
     size: 5Gi
 
 statsd:
@@ -74,25 +114,66 @@ dags:
     subPath: "dags"
 
 postgresql:
+  enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 16.1.0-debian-11-r15
+
+  # Bitnami PostgreSQL chart 13.x defaults to UID/GID 1001 and fsGroup 1001.
+  # Those are rejected by OpenShift restricted-v2 in this namespace, so keep
+  # the old OpenShift-compatible postgres UID and avoid the fsGroup/explicit seccomp defaults.
   primary:
+    podSecurityContext:
+      enabled: false
     containerSecurityContext:
+      enabled: true
       runAsUser: 1014620003
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
   readReplicas:
+    podSecurityContext:
+      enabled: false
     containerSecurityContext:
+      enabled: true
       runAsUser: 1014620003
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
   backup:
     cronjob:
+      podSecurityContext:
+        enabled: false
       containerSecurityContext:
+        enabled: true
         runAsUser: 1014620003
-     
+        runAsNonRoot: true
+        privileged: false
+        readOnlyRootFilesystem: false
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+
+  volumePermissions:
+    enabled: false
+  shmVolume:
+    enabled: false
 
 config:
-  webserver:
-    expose_config: 'True'  # by default this is 'False'
+  api:
+    expose_config: "True"
 
   smtp:
-    smtp_host: apps.smtp.gov.bc.ca  # befoult 'localhost'
-    smtp_mail_from: airflow@gov.bc.ca # default 'airflow@example.com'
-
-
-  
+    smtp_host: apps.smtp.gov.bc.ca
+    smtp_mail_from: airflow@gov.bc.ca

--- a/dags/MEDIS-ETL.py
+++ b/dags/MEDIS-ETL.py
@@ -38,6 +38,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 medis_schedule = Variable.get("medis_schedule")
 medis_last_load_date = Variable.get("medis_last_load_date")
@@ -78,11 +79,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/MEDIS-ETL.py
+++ b/dags/MEDIS-ETL.py
@@ -27,14 +27,14 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/MEDIS-ETL.py
+++ b/dags/MEDIS-ETL.py
@@ -34,7 +34,7 @@ from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperato
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/MEDIS-ODS-ETL.py
+++ b/dags/MEDIS-ODS-ETL.py
@@ -27,14 +27,14 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/MEDIS-ODS-ETL.py
+++ b/dags/MEDIS-ODS-ETL.py
@@ -38,6 +38,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 medis_ods_etl_schedule = Variable.get("medis_ods_etl_schedule")
 
@@ -77,11 +78,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/MEDIS-ODS-ETL.py
+++ b/dags/MEDIS-ODS-ETL.py
@@ -34,7 +34,7 @@ from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperato
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/PCD-ETL.py
+++ b/dags/PCD-ETL.py
@@ -32,7 +32,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/PCD-ETL.py
+++ b/dags/PCD-ETL.py
@@ -36,6 +36,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 pcd_etl_schedule = Variable.get("pcd_etl_schedule")
 
@@ -75,11 +76,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/PCD-ETL.py
+++ b/dags/PCD-ETL.py
@@ -26,13 +26,13 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/POLY-ETL.py
+++ b/dags/POLY-ETL.py
@@ -26,7 +26,7 @@ from airflow.models.dag import DAG
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.models import Variable
 

--- a/dags/POLY-ETL.py
+++ b/dags/POLY-ETL.py
@@ -29,6 +29,7 @@ from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperato
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 poly_etl_schedule = Variable.get("poly_etl_schedule")
 
@@ -68,11 +69,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/POLY-ETL.py
+++ b/dags/POLY-ETL.py
@@ -23,10 +23,10 @@ import datetime
 import pendulum
 
 from airflow.models.dag import DAG
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.models import Variable
 

--- a/dags/YTD-ETL-test.py
+++ b/dags/YTD-ETL-test.py
@@ -32,7 +32,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.email_operator import EmailOperator
+from airflow.operators.email import EmailOperator
 
 
 with DAG(

--- a/dags/YTD-ETL-test.py
+++ b/dags/YTD-ETL-test.py
@@ -26,13 +26,13 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.email import EmailOperator
+from airflow.providers.smtp.operators.smtp import EmailOperator
 
 
 with DAG(

--- a/dags/airflow-backup.py
+++ b/dags/airflow-backup.py
@@ -32,7 +32,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/airflow-backup.py
+++ b/dags/airflow-backup.py
@@ -36,6 +36,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 
 with DAG(
@@ -75,11 +76,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/airflow-backup.py
+++ b/dags/airflow-backup.py
@@ -26,13 +26,13 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/example_bash_operator_test.py
+++ b/dags/example_bash_operator_test.py
@@ -23,8 +23,8 @@ import datetime
 import pendulum
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 
 with DAG(
     dag_id="example_bash_operator_test",

--- a/dags/get_failed_ids_http_example.py
+++ b/dags/get_failed_ids_http_example.py
@@ -24,8 +24,8 @@ import pendulum
 
 from airflow.models.dag import DAG
 from airflow.providers.http.operators.http import HttpOperator
-from airflow.operators.python import PythonOperator
-from airflow.operators.email import EmailOperator
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.providers.smtp.operators.smtp import EmailOperator
 from airflow.exceptions import AirflowSkipException
 
 with DAG(

--- a/dags/get_failed_ids_http_example.py
+++ b/dags/get_failed_ids_http_example.py
@@ -24,8 +24,8 @@ import pendulum
 
 from airflow.models.dag import DAG
 from airflow.providers.http.operators.http import HttpOperator
-from airflow.operators.python_operator import PythonOperator
-from airflow.operators.email_operator import EmailOperator
+from airflow.operators.python import PythonOperator
+from airflow.operators.email import EmailOperator
 from airflow.exceptions import AirflowSkipException
 
 with DAG(

--- a/dags/get_failed_ids_http_example.py
+++ b/dags/get_failed_ids_http_example.py
@@ -27,6 +27,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.smtp.operators.smtp import EmailOperator
 from airflow.exceptions import AirflowSkipException
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 with DAG(
     dag_id="test_ETL_notification",
@@ -41,12 +42,20 @@ with DAG(
     def get_failed_ids(ds=None, **kwargs):
         ti = kwargs['ti']
         dag_run = kwargs['dag_run']
+        dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection([task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, skip this task
         if len(failed_upstream_task_ids) == 0:

--- a/dags/get_failed_ids_send_email.py
+++ b/dags/get_failed_ids_send_email.py
@@ -23,8 +23,8 @@ import datetime
 import pendulum
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.exceptions import AirflowSkipException
 from airflow.models import Variable

--- a/dags/get_failed_ids_send_email.py
+++ b/dags/get_failed_ids_send_email.py
@@ -28,6 +28,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.exceptions import AirflowSkipException
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 with DAG(
     dag_id="test_fail_success_send_email",
@@ -64,11 +65,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/get_failed_ids_send_email.py
+++ b/dags/get_failed_ids_send_email.py
@@ -24,7 +24,7 @@ import pendulum
 
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.exceptions import AirflowSkipException
 from airflow.models import Variable

--- a/dags/rls-backup.py
+++ b/dags/rls-backup.py
@@ -32,7 +32,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/rls-backup.py
+++ b/dags/rls-backup.py
@@ -36,6 +36,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 
 with DAG(
@@ -75,11 +76,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/rls-backup.py
+++ b/dags/rls-backup.py
@@ -26,13 +26,13 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/test-email.py
+++ b/dags/test-email.py
@@ -5,7 +5,7 @@ import datetime
 import pendulum
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils.email import send_email
 from airflow.operators.empty import EmptyOperator
 

--- a/dags/test-email.py
+++ b/dags/test-email.py
@@ -4,10 +4,10 @@ import datetime
 
 import pendulum
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.utils.email import send_email
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 
 def send_success_status_email(context):
     task_instance = context['task_instance']

--- a/dags/test_DAG.py
+++ b/dags/test_DAG.py
@@ -32,7 +32,7 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/dags/test_DAG.py
+++ b/dags/test_DAG.py
@@ -36,6 +36,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable
+from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 
 with DAG(
@@ -75,11 +76,17 @@ with DAG(
         dag_id = kwargs['dag'].dag_id
         # Get all tasks that are upstream of this task
         upstream_task_ids = ti.task.get_flat_relative_ids(upstream=True)
-        # Get list of all tasks that have failed for this DagRun
-        failed_task_instances = dag_run.get_task_instances(state='failed')
-        # Get intersection of the sets to get upstream tasks that failed
-        failed_upstream_task_ids = upstream_task_ids.intersection(
-            [task.task_id for task in failed_task_instances])
+        # Get upstream tasks that failed for this DagRun
+        failed_upstream_task_ids = {
+            task_id
+            for task_id in upstream_task_ids
+            if RuntimeTaskInstance.get_ti_count(
+                dag_id=dag_id,
+                run_ids=[dag_run.run_id],
+                task_ids=[task_id],
+                states=["failed"],
+            ) > 0
+        }
         print(f"Upstream tasks that failed: {failed_upstream_task_ids}")
         # If no upstream tasks have failed, send an email with success message
         if len(failed_upstream_task_ids) == 0:

--- a/dags/test_DAG.py
+++ b/dags/test_DAG.py
@@ -26,13 +26,13 @@ import kubernetes.client as k8s
 import kubernetes_asyncio.client as async_k8s
 
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.operators.python import PythonOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.exceptions import AirflowSkipException
 from airflow.utils.email import send_email
 from airflow.models import Variable

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@
 # The following variables are supported:
 #
 # AIRFLOW_IMAGE_NAME           - Docker image name used to run Airflow.
-#                                Default: apache/airflow:2.9.0
+#                                Default: apache/airflow:3.2.2
 # AIRFLOW_UID                  - User ID in Airflow containers
 #                                Default: 50000
 # AIRFLOW_PROJ_DIR             - Base path to which all the files will be volumed.
@@ -49,7 +49,7 @@ x-airflow-common:
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
-  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.9.0}
+  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:3.2.2}
   # build: .
   environment:
     &airflow-common-env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -117,11 +117,11 @@ services:
 
   airflow-webserver:
     <<: *airflow-common
-    command: webserver
+    command: api-server
     ports:
       - "8080:8080"
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/monitor/health"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary

This PR prepares **MEDIS Scheduler** for the **Airflow 3.2.2** upgrade on OpenShift and updates local development compatibility. It also fixes DAG email notification logic that failed after the upgrade because `dag_run.get_task_instances()` is no longer available in the Airflow 3 task runtime context.

## Changes

### Local Airflow runtime updates

* Updated the local Airflow image in `docker-compose.yaml` to **Airflow 3.2.2**.
* Updated the local web component command:

  * `webserver` → `api-server`
* Updated the local web health check:

  * `/health` → `/api/v2/monitor/health`

### DAG import updates

Replaced deprecated Airflow 2 imports with Airflow 3 provider-specific imports:

* `airflow.operators.bash` → `airflow.providers.standard.operators.bash`
* `airflow.operators.empty` → `airflow.providers.standard.operators.empty`
* `airflow.operators.python` → `airflow.providers.standard.operators.python`
* `airflow.operators.email` → `airflow.providers.smtp.operators.smtp`

### Helm / OpenShift updates

* Pinned Airflow to **3.2.2**.
* Updated Helm values for the Airflow 3 chart structure.
* Replaced Airflow 2 `webserver` settings with Airflow 3 `apiServer` settings.
* Moved `config.webserver.expose_config` to `config.api.expose_config`.
* Disabled legacy `airflowLocalSettings` injection.
* Configured migration and create-user jobs as normal Kubernetes jobs instead of Helm hooks.
* Increased migration wait timeout for existing metadata DB upgrades.
* Pinned PostgreSQL to the working legacy Bitnami image:

```text
bitnamilegacy/postgresql:16.1.0-debian-11-r15
```

* Preserved OpenShift-specific UID/GID/security context values.
* Preserved PROD-specific values, including:

  * PROD UID range
  * PROD PostgreSQL `runAsUser`
  * PROD Redis, statsd, and pgbouncer UIDs
  * PROD DAG git-sync branch: `main`

### DAG notification compatibility

* Replaced Airflow 2.x notification logic using:

```python
dag_run.get_task_instances(state="failed")
```

* Updated notification task logic to use Airflow 3-compatible task state lookup.
* Preserved existing notification behavior:

  * Send success email when no upstream task failed.
  * Send failure email with failed upstream task IDs when upstream failures exist.
* Avoided unrelated cleanup/refactoring to keep DAG changes minimal and easy to review.

## Why

After upgrading to Airflow 3.2.2, notification tasks failed with:

```text
AttributeError: 'DagRun' object has no attribute 'get_task_instances'
```

This PR updates the runtime, Helm configuration, DAG imports, and notification logic so MEDIS Scheduler can run correctly on Airflow 3.2.2 in both local and OpenShift environments.
